### PR TITLE
Pointing directly to our new repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,13 @@
 
 Thank you for landing here!
 
- We have decided to deprecate aerogear-ios development and focus all our efforts in bringing the same feature-set (and  more) in a new modular set of libraries that utilize [Swift programming language](https://developer.apple.com/swift/) as their base.  Already a small but important feature set of libraries has been implemented. See the following repositories for more information on each respective library.
+ We have decided to deprecate aerogear-ios development and focus all our efforts in bringing the same feature-set (and more) in a new modular set of libraries that utilize [Swift programming language](https://developer.apple.com/swift/) as their base.  Already a small but important feature set of libraries has been implemented. See the following repositories for more information on each respective library!
 
-aerogear-ios '_umbrella release 2.0_'
-
-- [aerogear-ios-http v0.1](https://github.com/aerogear/aerogear-ios-http/tree/0.1)
-- [aerogear-ios-oauth2 v0.1 ](https://github.com/aerogear/aerogear-ios-oauth2/tree/0.1)
-- [aerogear-ios-httpstub v0.1](https://github.com/aerogear/aerogear-ios-httpstub/tree/0.1)
-- [aerogear-ios-cookbook v0.1](https://github.com/aerogear/aerogear-ios-cookbook/tree/0.1)
-- [aerogear-backend-cookbook v0.1](https://github.com/aerogear/aerogear-backend-cookbook/tree/ios_2.0)
-- [aerogear-ios-push v2.0](https://github.com/aerogear/aerogear-ios-push/tree/2.0)
-
+- [aerogear-ios-http](https://github.com/aerogear/aerogear-ios-http)
+- [aerogear-ios-oauth2](https://github.com/aerogear/aerogear-ios-oauth2)
+- [aerogear-ios-httpstub](https://github.com/aerogear/aerogear-ios-httpstub)
+- [aerogear-ios-cookbook](https://github.com/aerogear/aerogear-ios-cookbook)
+- [aerogear-ios-push](https://github.com/aerogear/aerogear-ios-push)
 
 If you are looking for the previous versions of aerogear-ios,  you might want to have a look at this [branch](https://github.com/aerogear/aerogear-ios/tree/1.6.x). Note that no further development is done on this branch apart from any critical bug fixes.
 


### PR DESCRIPTION
removing the 'older' tags - pointing to latest greatest

also removing the backend link, since that is linked to from the iOS cookbook, where needed